### PR TITLE
Updated version and documentation to support 0.8.1. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 group 'org.lightningj'
 
-version '0.8.0-Beta'
+version '0.8.1-Beta'
 
 apply plugin: "groovy"
 apply plugin: 'com.google.protobuf'

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -41,6 +41,8 @@ to the license agreement can be found link:LICENSE.txt[here].
 
 == Whats New
 
+* 0.8.0-Beta     : Generated against LND 0.8.1 API, (Identical to 0.8.0 from an GRPC perspective, so using lightningJ
+ 0.8.0 should work as well.)
 * 0.8.0-Beta     : Generated against LND 0.8.0 API
 * 0.8.0-Beta-rc1 : Added build support for JDK 11 and upgraded gradlew to 5.6 and GRPC to 1.23.0.
                    Generated API against LND 0.8.0-rc1 and fixed issue #43 of Map fields not serialized


### PR DESCRIPTION
(Identical to 0.8.0 from an GRPC perspective, so using lightningJ
 0.8.0 should work as well.)