### PR TITLE
Upgrade gRPC and protobuf dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 build
+.idea

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         maven { url "https://dl.bintray.com/asciidoctor/maven/"}
     }
     dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.10"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.19"
 
         classpath "org.spockframework:spock-core:1.3-groovy-2.5"
 
@@ -52,13 +52,18 @@ buildscript {
     }
 }
 
+ext {
+    grpcVersion = "1.49.2"
+    protobufVersion = "3.21.7"
+}
+
 dependencies {
     //gRPC
-    compile 'com.google.api.grpc:googleapis-common-protos:0.0.3'
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.40.Final'
-    compile 'io.grpc:grpc-netty-shaded:1.39.0'
-    compile 'io.grpc:grpc-protobuf:1.39.0'
-    compile 'io.grpc:grpc-stub:1.39.0'
+    compile 'com.google.api.grpc:proto-google-common-protos:2.9.6'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.54.Final'
+    compile "io.grpc:grpc-netty-shaded:$grpcVersion"
+    compile "io.grpc:grpc-protobuf:$grpcVersion"
+    compile "io.grpc:grpc-stub:$grpcVersion"
 
     // JSON-P
     compile 'javax.json:javax.json-api:1.0'
@@ -90,11 +95,11 @@ dependencies {
  */
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.7.1"
+        artifact = "com.google.protobuf:protoc:$protobufVersion"
     }
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.23.0'
+            artifact = "io.grpc:protoc-gen-grpc-java:$grpcVersion"
         }
     }
     generateProtoTasks {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -10,15 +10,16 @@ repositories {
    // maven { url "http://oss.sonatype.org/content/repositories/snapshots/" }
 }
 
-
+ext {
+    grpcVersion = "1.49.2"
+}
 
 dependencies {
     //gRPC
-    compile group: 'com.google.api.grpc', name: 'googleapis-common-protos', version: '0.0.3'
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.6.Final'
-    compile 'io.grpc:grpc-netty:1.7.0'
-    compile 'io.grpc:grpc-protobuf:1.7.0'
-    compile 'io.grpc:grpc-stub:1.7.0'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.54.Final'
+    compile "io.grpc:grpc-netty:$grpcVersion"
+    compile "io.grpc:grpc-protobuf:$grpcVersion"
+    compile "io.grpc:grpc-stub:$grpcVersion"
 
     // JAX-B dependencies for JDK 9+
     compile "javax.xml.bind:jaxb-api:2.2.11"


### PR DESCRIPTION
The current gRPC dependencies won't run on Mac M1 (or ARM). In order to get LightningJ working I had to update some dependencies.

This is just a PR I quickly drafted after I get it working on my machine ;). I tested this with a separate project by retrieving a list of channels, invoices and payments. 

Please let me know what you think of it and what more actions are needed.