### PR TITLE
build(deps): update protobuf and grpc dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.16"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.8.19"
 
         // optional dependencies for using Spock
         classpath "org.hamcrest:hamcrest-core:1.3" // only necessary if Hamcrest matchers are used
@@ -27,7 +27,7 @@ buildscript {
 plugins {
     id 'java-library'
     id 'groovy'
-    id 'com.google.protobuf' version "0.8.16"
+    id 'com.google.protobuf' version "0.8.19"
     id 'idea'
     id 'project-report'
     id 'org.ajoberstar.git-publish' version "3.0.1"
@@ -51,8 +51,8 @@ repositories {
 
 dependencies {
     //gRPC
-    implementation 'com.google.api.grpc:proto-google-common-protos:2.9.6'
-    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.54.Final'
+    implementation 'com.google.api.grpc:proto-google-common-protos:2.31.0'
+    implementation 'io.netty:netty-tcnative-boringssl-static:2.0.62.Final'
     api "io.grpc:grpc-netty-shaded:$grpcVersion"
     implementation "io.grpc:grpc-protobuf:$grpcVersion"
     implementation "io.grpc:grpc-stub:$grpcVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-// Maven Central Repository publishing, set correct data in user dir .gradle/gradle.properties
+# Maven Central Repository publishing, set correct data in user dir .gradle/gradle.properties
 ossrhUsername = 'set in gradle.properties'
 ossrhPassword = 'set in gradle.properties'
 
-grpcVersion=1.58.0
-protobufVersion=3.21.7
+grpcVersion=1.61.0
+protobufVersion=3.22.5


### PR DESCRIPTION
- `protobuf-gradle-plugin` from `v0.8.16` to `v0.8.19`
- `proto-google-common-protos` from `v2.9.6` to `v2.31.0`
- `netty-tcnative-boringssl-static` from `v2.0.54.Final` to `v2.0.62.Final`
- `grpc` from `v1.58.0` to `v1.61.0`
- `protobuf` from `v3.21.7` to `v3.22.5`

Wanted to update `protobuf to `v3.25.2` (as well as `protobuf-gradle-plugin` to `v0.9.4`), but I could not get rid of compilation errors. Maybe you can take a look and see what I did wrong?